### PR TITLE
update wrapped near icon

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,6 +1,6 @@
 export default {
   'wrap.near':
-    'https://fluxprotocol.eth.link/static/media/wrapped-near.8b3a5e4b.svg',
+    'https://imgur.com/AaM3AbV.jpg',
   '6b175474e89094c44da98b954eedeac495271d0f.factory.bridge.near':
     'https://s2.coinmarketcap.com/static/img/coins/64x64/4943.png',
   'berryclub.ek.near': 'https://assets.onlinelabels.com/images/clip-art/pitr/pitr_Bananas_icon.png',


### PR DESCRIPTION
Created a temporary wrapped NEAR icon that is a little cleaner and easier to understand.

<img width="90" alt="Screen Shot 2021-04-06 at 1 17 29 AM" src="https://user-images.githubusercontent.com/58483342/113680672-f757d280-9675-11eb-9361-61d058f52555.png">

vs.

<img width="113" alt="Screen Shot 2021-04-06 at 1 17 21 AM" src="https://user-images.githubusercontent.com/58483342/113680685-faeb5980-9675-11eb-89c3-21ecf1dbe25c.png">
