### PR TITLE
Increase prepaid gas for withdraw

### DIFF
--- a/src/services/token.ts
+++ b/src/services/token.ts
@@ -162,6 +162,7 @@ export const withdraw = async ({
         {
           methodName: 'withdraw',
           args: { token_id: token.id, amount: parsedAmount, unregister },
+          gas: '50000000000000',
           amount: ONE_YOCTO_NEAR,
         },
       ],


### PR DESCRIPTION
Withdraw fails because gas is exceeded.