### PR TITLE
Feat/display token ID tooltips

### DIFF
--- a/src/components/forms/TokenAmount.tsx
+++ b/src/components/forms/TokenAmount.tsx
@@ -79,9 +79,10 @@ export default function TokenAmount({
             selectedToken && (
               <div
                 className="flex items-center justify-center font-semibold pl-3 pr-3"
-                data-tip={selectedToken.id}
+                data-tip={selectedToken.id === "NEAR" ? "" : selectedToken.id}
                 data-type="dark"
                 data-effect="solid"
+                data-delay-show={300}
               >
                 <Icon token={selectedToken} />
                 {tokens.length > 1 && (

--- a/src/components/forms/TokenAmount.tsx
+++ b/src/components/forms/TokenAmount.tsx
@@ -10,6 +10,7 @@ import AddToken from './AddToken';
 import { FaAngleDown } from 'react-icons/fa';
 import { ArrowDownGreen } from '../icon';
 import { toPrecision, toReadableNumber } from '../../utils/numbers';
+import ReactTooltip from 'react-tooltip';
 
 interface TokenAmountProps {
   amount?: string;
@@ -76,13 +77,19 @@ export default function TokenAmount({
           addToken={addToken}
           selected={
             selectedToken && (
-              <div className="flex items-center justify-center font-semibold pl-3 pr-3">
+              <div
+                className="flex items-center justify-center font-semibold pl-3 pr-3"
+                data-tip={selectedToken.id}
+                data-type="dark"
+                data-effect="solid"
+              >
                 <Icon token={selectedToken} />
                 {tokens.length > 1 && (
                   <div className="pl-2 text-xs">
                     <ArrowDownGreen />
                   </div>
                 )}
+                <ReactTooltip />
               </div>
             )
           }

--- a/src/components/tokens/Token.tsx
+++ b/src/components/tokens/Token.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TokenMetadata } from '../../services/ft-contract';
 import Icon from './Icon';
+import ReactTooltip from 'react-tooltip';
 
 interface TokenProps {
   token: TokenMetadata;
@@ -9,13 +10,16 @@ interface TokenProps {
 }
 
 export default function Token({ token, onClick, render }: TokenProps) {
-  const { icon, symbol } = token;
+  const { id, icon, symbol } = token;
   return (
     <section
       className={`${
         onClick ? 'cursor-pointer' : ' '
       } flex justify-between align-center py-4 px-2 w-full text-center hover:bg-secondaryScale-100`}
       onClick={() => onClick && onClick(token)}
+      data-tip={id}
+      data-type="dark"
+      data-delay-show={300}
     >
       <div className="w-32">
         <div
@@ -31,6 +35,7 @@ export default function Token({ token, onClick, render }: TokenProps) {
         </div>
       </div>
       {render && render(token)}
+      <ReactTooltip />
     </section>
   );
 }

--- a/src/components/tokens/Token.tsx
+++ b/src/components/tokens/Token.tsx
@@ -17,7 +17,7 @@ export default function Token({ token, onClick, render }: TokenProps) {
         onClick ? 'cursor-pointer' : ' '
       } flex justify-between align-center py-4 px-2 w-full text-center hover:bg-secondaryScale-100`}
       onClick={() => onClick && onClick(token)}
-      data-tip={id}
+      data-tip={id === "NEAR" ? "" : id}
       data-type="dark"
       data-delay-show={300}
     >

--- a/src/pages/pools/DetailsPage.tsx
+++ b/src/pages/pools/DetailsPage.tsx
@@ -305,11 +305,18 @@ export function PoolDetailsPage() {
             <Icon icon={tokens[1].icon} />
           </div>
         </div>
-        <div className="text-center border-b">
-          <div className="inline-flex text-center text-base font-semibold pt-2 pb-6">
+        <div className="text-center">
+          <div className="inline-flex text-center text-base font-semibold pt-2">
             <div>{tokens[0].symbol}</div>
             <div className="px-2">-</div>
             <div>{tokens[1].symbol}</div>
+          </div>
+        </div>
+        <div className="text-center border-b">
+          <div className="inline-flex text-center text-xs pb-6">
+            <div>{tokens[0].id}</div>
+            <div className="px-2">-</div>
+            <div>{tokens[1].id}</div>
           </div>
         </div>
         <div className="text-xs font-semibold text-gray-600 pt-6">

--- a/src/pages/pools/DetailsPage.tsx
+++ b/src/pages/pools/DetailsPage.tsx
@@ -313,7 +313,7 @@ export function PoolDetailsPage() {
           </div>
         </div>
         <div className="text-center border-b">
-          <div className="inline-flex text-center text-xs pb-6">
+          <div className="inline-flex flex-wrap justify-center text-center text-xs pb-6">
             <div>{tokens[0].id}</div>
             <div className="px-2">-</div>
             <div>{tokens[1].id}</div>


### PR DESCRIPTION
Closes #67 

Added hoverable tooltips with the corresponding token ID/address to the swap form, select token menu, and small text underneath the token symbols in the pool details page. Users can use this to verify the legitimacy of a token.

![Screenshot from 2021-05-16 10-55-03](https://user-images.githubusercontent.com/4026659/118402194-e0be7700-b636-11eb-8b49-e84d86cef519.png)
![Screenshot from 2021-05-16 10-55-32](https://user-images.githubusercontent.com/4026659/118402195-e0be7700-b636-11eb-829c-ea8a9e53778b.png)
![Screenshot from 2021-05-16 10-56-22](https://user-images.githubusercontent.com/4026659/118402196-e1570d80-b636-11eb-8c08-11688d01681b.png)
