### PR TITLE
fix TODO: Check if there can be a better way. If not need to iterate through all pages to find pools

### DIFF
--- a/src/store/RefDatabase.ts
+++ b/src/store/RefDatabase.ts
@@ -55,6 +55,21 @@ class RefDatabase extends Dexie {
     return this.farms;
   }
 
+  public async getCachedPoolsByTokens(args: {
+    token1Id: string;
+    token2Id: string;
+  }): Promise<Pool[]> {
+    const { token1Id, token2Id } = args;
+    const pools1 = await this.allPools()
+      .where({ token1Id: token1Id, token2Id: token2Id })
+      .toArray();
+    const pools2 = await this.allPools()
+      .where({ token2Id: token1Id, token1Id: token2Id })
+      .toArray();
+    return [...pools1, ...pools2]
+  }
+
+
   public searchPools(args: any, pools: Pool[]): Pool[] {
     if (args.tokenName === '') return pools;
     return _.filter(pools, (pool: Pool) => {


### PR DESCRIPTION
## Problem:
Iterating through all pages to find pools will cost a lot if there are more pools in the future.

## Here is what I thought: 
- Firstly we could get IDs based on two tokens from cached pools to narrow the range.
- And we send a request to the smart contract by "getPoolsByIds" to get the pools, then filter it. 
- It could be more efficient because we narrow the range of pools. 

